### PR TITLE
Untie patch version, remove inlining from scala.*

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -45,7 +45,6 @@ object ProjectKeys {
       "-Ywarn-extra-implicit",
       "-Ywarn-unused:explicits,patvars,imports,privates,locals,implicits",
       "-opt:l:method,inline",
-      "-opt-inline-from:scala.**",
       "-opt-inline-from:scalaz.**",
       "-opt-inline-from:fommil.**",
       "-opt-inline-from:magnolia.**",


### PR DESCRIPTION
See https://github.com/scala/bug/issues/12100#issuecomment-666037368

>Inlining from the standard library means the plugin is tied to the scala version it is compiled with.

If I understand correctly, this line makes derivation code bound to very specific scala patch version, making it binary incompatible with other versions, resulting in runtime errors. I'm facing that in our project when there is 2.12.12 in classpath instead of previous 2.12.10
